### PR TITLE
Fix daemon inactivity in startup.

### DIFF
--- a/bin/synchly.service
+++ b/bin/synchly.service
@@ -16,6 +16,8 @@ After=network.target
 [Service]
 WorkingDirectory=/usr/local/lib/node_modules/synchly/bin/
 ExecStart=/usr/bin/node synchly --start
+Type=simple
+Restart=always
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=default.target


### PR DESCRIPTION
This commit ensures that the synchly service running as a daemon
gets into active state in the startup/reboot.